### PR TITLE
feat: add `exclude_permissions`

### DIFF
--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -160,6 +160,12 @@ section {
         type        = set(string)
         default     = []
       }
+
+      variable "exclude_permissions" {
+        description = "A set of permissions to be excluded from the cloned permissions."
+        type        = set(string)
+        default     = []
+      }
     }
 
     section {

--- a/imports.tf
+++ b/imports.tf
@@ -6,5 +6,5 @@ data "google_iam_role" "role" {
 }
 
 locals {
-  permissions_from_roles = toset(flatten([for k, v in data.google_iam_role.role : v.included_permissions]))
+  permissions_from_roles = setsubtract(flatten([for k, v in data.google_iam_role.role : v.included_permissions]), var.exclude_permissions)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "permissions_from_roles" {
   default     = []
 }
 
+variable "exclude_permissions" {
+  type        = set(string)
+  description = "(Optional) The names of the permissions to be excluded from the cloned permissions."
+  default     = []
+}
+
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULE CONFIGURATION PARAMETERS
 # These variables are used to configure the module.


### PR DESCRIPTION
New argument added as required to exclude certain permissions that can't be added to custom created roles.