### PR TITLE
feat: add `permissions_chunck_size`

### DIFF
--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -155,14 +155,20 @@ section {
     section {
       title = "Extended Resource Configuration"
 
-      variable "permissions_from_roles" {
-        description = "A set of role names of existing roles to have the permissions cloned from."
+      variable "exclude_permissions" {
+        description = "A set of permissions to be excluded from the cloned permissions."
         type        = set(string)
         default     = []
       }
 
-      variable "exclude_permissions" {
-        description = "A set of permissions to be excluded from the cloned permissions."
+      variable "permissions_chunk_size" {
+        type        = number
+        description = "The maximum size of permissions chunk to split the cloned list with."
+        default     = 3000
+      }
+
+      variable "permissions_from_roles" {
+        description = "A set of role names of existing roles to have the permissions cloned from."
         type        = set(string)
         default     = []
       }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   permissions = setunion(var.permissions, local.permissions_from_roles)
 
-  permissions_chunks = chunklist(local.permissions, 3000)
+  permissions_chunks = chunklist(local.permissions, var.permissions_chunk_size)
 
   number_of_chunks = length(local.permissions_chunks)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "permissions_from_roles" {
   default     = []
 }
 
+variable "permissions_chunk_size" {
+  type        = number
+  description = "(Optional) The maximum count of permissions chunk to split the cloned list with."
+  default     = 3000
+}
+
 variable "exclude_permissions" {
   type        = set(string)
   description = "(Optional) The names of the permissions to be excluded from the cloned permissions."


### PR DESCRIPTION
New argument added to adjust the chunk size used to split the list of the permissions as needed.